### PR TITLE
code review guidelines: enforce backwards-compatibility in migrations

### DIFF
--- a/src/reviewer-lotto.coffee
+++ b/src/reviewer-lotto.coffee
@@ -31,23 +31,25 @@ module.exports = (robot) ->
   ghOrg                 = process.env.HUBOT_GITHUB_ORG
   ghDefaultReviewerTeam = process.env.HUBOT_GITHUB_REVIEWER_TEAM
   ghWithAvatar          = process.env.HUBOT_GITHUB_WITH_AVATAR
-  codeReviewChecklist   = "\n\n#### Code Review Checklist:\n"                                      +
-                          "- **All Code**\n"                                                       +
-                          "  - [ ] Intent of the code/changes are clear?\n"                        +
-                          "  - [ ] Comments are provided whenever something may be unintuitive?\n" +
-                          "  - [ ] Implementation of the code/changes makes sense?\n"              +
-                          "  - [ ] Code/changes are free of typos and basic errors?\n"             +
-                          "  - [ ] Code/specs can be run on your local machine?\n"                 +
-                          "  - [ ] Changes are not breaking a public API?\n"                       +
-                          "    - [ ] If so, documentation is updated?\n"                           +
-                          "  - [ ] Code/changes don't reimplement existing features?\n"            +
-                          "  - [ ] Performance implications have been considered?\n"               +
-                          "  - [ ] Code/changes include all appropriate tests?\n"                  +
-                          "- **Migrations**\n"                                                     +
-                          "  - [ ] All migrations run on a clone of production data?\n"            +
-                          "  - [ ] All migrations are reversable: `rake db:rollback`?\n"           +
-                          "- **Rake Tasks**\n"                                                     +
-                          "  - [ ] All rake tasks run on a clone of production data?\n"            +
+  codeReviewChecklist   = "\n\n#### Code Review Checklist:\n"                                            +
+                          "- **All Code**\n"                                                             +
+                          "  - [ ] Intent of the code/changes are clear?\n"                              +
+                          "  - [ ] Comments are provided whenever something may be unintuitive?\n"       +
+                          "  - [ ] Implementation of the code/changes makes sense?\n"                    +
+                          "  - [ ] Code/changes are free of typos and basic errors?\n"                   +
+                          "  - [ ] Code/specs can be run on your local machine?\n"                       +
+                          "  - [ ] Changes are not breaking a public API?\n"                             +
+                          "    - [ ] If so, documentation is updated?\n"                                 +
+                          "  - [ ] Code/changes don't reimplement existing features?\n"                  +
+                          "  - [ ] Performance implications have been considered?\n"                     +
+                          "  - [ ] Code/changes include all appropriate tests?\n"                        +
+                          "- **Migrations**\n"                                                           +
+                          "  - [ ] All migrations run on a clone of production data?\n"                  +
+                          "  - [ ] All migrations are reversable: `rake db:rollback`?\n"                 +
+                          "  - [ ] All migrations are backwards-compatible?\n"                           +
+                          "    - [ ] All migrations check for the existence of any models referenced?\n" +                          
+                          "- **Rake Tasks**\n"                                                           +
+                          "  - [ ] All rake tasks run on a clone of production data?\n"                  +
                           "  - [ ] Code/changes include all appropriate tests?"
   normalMessage         = process.env.HUBOT_REVIEWER_LOTTO_MESSAGE || "Please review this." + codeReviewChecklist
   politeMessage         = process.env.HUBOT_REVIEWER_LOTTO_POLITE_MESSAGE || "#{normalMessage} :bow::bow::bow::bow:" + codeReviewChecklist

--- a/src/reviewer-lotto.coffee
+++ b/src/reviewer-lotto.coffee
@@ -31,25 +31,22 @@ module.exports = (robot) ->
   ghOrg                 = process.env.HUBOT_GITHUB_ORG
   ghDefaultReviewerTeam = process.env.HUBOT_GITHUB_REVIEWER_TEAM
   ghWithAvatar          = process.env.HUBOT_GITHUB_WITH_AVATAR
-  codeReviewChecklist   = "\n\n#### Code Review Checklist:\n"                                            +
-                          "- **All Code**\n"                                                             +
-                          "  - [ ] Intent of the code/changes are clear?\n"                              +
-                          "  - [ ] Comments are provided whenever something may be unintuitive?\n"       +
-                          "  - [ ] Implementation of the code/changes makes sense?\n"                    +
-                          "  - [ ] Code/changes are free of typos and basic errors?\n"                   +
-                          "  - [ ] Code/specs can be run on your local machine?\n"                       +
-                          "  - [ ] Changes are not breaking a public API?\n"                             +
-                          "    - [ ] If so, documentation is updated?\n"                                 +
-                          "  - [ ] Code/changes don't reimplement existing features?\n"                  +
-                          "  - [ ] Performance implications have been considered?\n"                     +
-                          "  - [ ] Code/changes include all appropriate tests?\n"                        +
-                          "- **Migrations**\n"                                                           +
-                          "  - [ ] All migrations run on a clone of production data?\n"                  +
-                          "  - [ ] All migrations are reversable: `rake db:rollback`?\n"                 +
-                          "  - [ ] All migrations are backwards-compatible?\n"                           +
-                          "    - [ ] All migrations check for the existence of any models referenced?\n" +                          
-                          "- **Rake Tasks**\n"                                                           +
-                          "  - [ ] All rake tasks run on a clone of production data?\n"                  +
+  codeReviewChecklist   = "\n\n#### Code Review Checklist:\n"                                                +
+                          "- **All Code**\n"                                                                 +
+                          "  - [ ] Intent of the code/changes are clear?\n"                                  +
+                          "  - [ ] Comments are provided whenever something may be unintuitive?\n"           +
+                          "  - [ ] Implementation of the code/changes makes sense?\n"                        +
+                          "  - [ ] Code/changes are free of typos and basic errors?\n"                       +
+                          "  - [ ] Code/specs can be run on your local machine?\n"                           +
+                          "  - [ ] Changes are not breaking a public API?\n"                                 +
+                          "    - [ ] If so, documentation is updated?\n"                                     +
+                          "  - [ ] Code/changes don't reimplement existing features?\n"                      +
+                          "  - [ ] Performance implications have been considered?\n"                         +
+                          "  - [ ] Code/changes include all appropriate tests?\n"                            +
+                          "- **Migrations**\n"                                                               +
+                          "  - [ ] Run on clone of prod data, reversible, backwards-compatible?\n"           +                          
+                          "- **Rake Tasks**\n"                                                               +
+                          "  - [ ] Run on a clone of production data?\n"                                     +
                           "  - [ ] Code/changes include all appropriate tests?"
   normalMessage         = process.env.HUBOT_REVIEWER_LOTTO_MESSAGE || "Please review this." + codeReviewChecklist
   politeMessage         = process.env.HUBOT_REVIEWER_LOTTO_POLITE_MESSAGE || "#{normalMessage} :bow::bow::bow::bow:" + codeReviewChecklist


### PR DESCRIPTION
**Description** 

Migrations should be backwards compatible. If there is a migration that
would be incompatible with existing code, users would experience downtime
during the migration or we'd need to use subdeployments.

To reduce the complexity of our tooling, splitting the change between
two deployments in a way that the migration never results in
a period of backwards incompatible code is the simplest solution for now.

There's a bunch of white line additions to make the `+` line up. The only
things I added were

```
- [ ] All migrations are backwards-compatible?\n"
- [ ] All migrations check for the existence of any models referenced?\n"
```

This applies to migrations in future PRs, not past migrations. 

There is a discussion in the original issue.

**Steps to test**

N/A

**Documentation**

N/A

**Fixes**

Fixes https://github.com/shuddle/engineering/issues/44